### PR TITLE
Fixed an inability to setup notifications

### DIFF
--- a/phpbb/notification/type/admin_activate_user.php
+++ b/phpbb/notification/type/admin_activate_user.php
@@ -159,7 +159,7 @@ class admin_activate_user extends \phpbb\notification\type\base
 	/**
 	* {@inheritdoc}
 	*/
-	public function create_insert_array($user, $pre_create_data)
+	public function create_insert_array($user, $pre_create_data = array())
 	{
 		$this->set_data('user_actkey', $user['user_actkey']);
 		$this->notification_time = $user['user_regdate'];


### PR DESCRIPTION
Недавно поймал у себя вот такую ошибочку
```
Fatal error: Declaration of phpbb\notification\type\admin_activate_user::create_insert_array($user, $pre_create_data) must be compatible with phpbb\notification\type\base::create_insert_array($type_data, $pre_create_data = Array) in www/forum/phpbb/notification/type/admin_activate_user.php on line 162
```

К счастью, очень легко лечится.